### PR TITLE
Fix mobile navigation and responsive layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,15 +1,38 @@
 const sectBtn = document.querySelectorAll('.control');
+const sections = document.querySelectorAll('.section');
+
+function setActiveSection(sectionId) {
+    if (!sectionId) {
+        return;
+    }
+
+    sections.forEach((section) => {
+        section.classList.remove('active1');
+    });
+
+    const targetSection = document.getElementById(sectionId);
+    if (targetSection) {
+        targetSection.classList.add('active1');
+        targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
 
 function PageTransitions(){
-    //Button click to navigate to pages
+    //Button click to navigate to pages or sections
     for (let i = 0; i < sectBtn.length; i++){
         sectBtn[i].addEventListener('click', function(){
             const page = this.dataset.page;
+            const sectionId = this.dataset.id;
             if(page){
                 window.location.href = page;
+            } else if (sectionId) {
+                setActiveSection(sectionId);
             }
+
             let currentBtn = document.querySelectorAll('.active-btn');
-            currentBtn[0].className = currentBtn[0].className.replace('active-btn', '');
+            if (currentBtn.length) {
+                currentBtn[0].className = currentBtn[0].className.replace('active-btn', '');
+            }
             this.className += ' active-btn';
         })
     }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1202,6 +1202,16 @@ section {
     width: 90%;
   }
 
+  .btn-con {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .main-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
   .about-container {
     -ms-grid-columns: 1fr;
     grid-template-columns: 1fr;
@@ -1293,6 +1303,10 @@ section {
 }
 
 @media screen and (max-width: 1280px) {
+  .header-content .right-header {
+    padding-right: 4rem;
+  }
+
   .sec5 {
     padding: 3rem 6rem !important;
   }
@@ -1310,6 +1324,12 @@ section {
 
   .theme-btn i {
     font-size: 1rem;
+  }
+}
+
+@media screen and (max-width: 1100px) {
+  .header-content .right-header {
+    padding-right: 0;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The navigation controls did not reliably switch sections on the single-page layout and sometimes attempted full-page navigation instead.  
- The navbar active state removal could error when no `.active-btn` existed.  
- The hero buttons and header spacing were not wrapping or spacing correctly on narrow screens which broke mobile rendering.  
- Theme persistence behavior should remain unchanged while improving mobile UX.

### Description
- Update `app.js` to add `setActiveSection(sectionId)` and use `data-id` to switch in-page sections, while preserving `data-page` behavior for page links.  
- Ensure safe removal of the previous `.active-btn` and add `scrollIntoView` for smooth mobile section focus.  
- Adjust `styles/styles.css` responsive rules to wrap `.btn-con`, make `.main-btn` full-width on small screens, and reduce right padding on the header at narrower breakpoints.  
- Add/modify media queries (`max-width: 1280px`, `1100px`, `800px`) to improve layout and control placement on mobile.

### Testing
- Started a local static server with `python -m http.server 8000`, which launched successfully.  
- Ran a Playwright mobile viewport script to load `index.html` at `390x844` and produced a mobile screenshot artifact (`artifacts/mobile-index.png`) successfully.  
- No unit tests exist for this static site, so no automated test suite was run.  
- Changes were committed and are ready for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cba646ba8832bbdd834edd8a4b084)